### PR TITLE
Prevent to post new task with enter key

### DIFF
--- a/app/assets/javascripts/ktra.js.coffee
+++ b/app/assets/javascripts/ktra.js.coffee
@@ -1,0 +1,2 @@
+jQuery ->
+  $(document).on "keypress", "input:not(.allow-submit)", (event) -> event.which != 13

--- a/app/views/tasks/form/_title.html.haml
+++ b/app/views/tasks/form/_title.html.haml
@@ -1,2 +1,2 @@
-= f.text_field :title, class: 'task-title', placeholder: placeholder, required: true
+= f.text_field :title, class: 'task-title', placeholder: placeholder, required: true, class: "#{'allow-submit' unless local_assigns[:new_task]}"
 %i.fa.fa-pencil

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -10,7 +10,7 @@
             - @task.errors.full_messages.each do |msg|
               %li= msg
       .field
-        = render ('tasks/form/title'), f: f, placeholder: 'NEW TASK TITLE'
+        = render ('tasks/form/title'), f: f, placeholder: 'NEW TASK TITLE', new_task: true
       .field.point-radio
         = render ('tasks/form/points'), f: f
         = f.hidden_field :status, value: 'unstarted'


### PR DESCRIPTION
- エンターキーで新しいタスクをpost できないようにした（refs #26
- iPhoneだと間違えてradioを押さないままPostしやすいので
- .デフォルトのimputは submit できない感じにして、`.allow-submit` という classがついてれば enterでpostできるようにした
- 参考: http://qiita.com/awakia/items/17457d6b1809dd803413

逆の方がいいのかなーという気もしてきた（デフォルトはenterキーでsubmitできるようにして、tasks#new だけ .disallow-submit みたいな
