### PR TITLE
Fix github link on footer

### DIFF
--- a/app/views/application/_footer.html.haml
+++ b/app/views/application/_footer.html.haml
@@ -17,7 +17,10 @@
     =link_to '#p4d', 'http://prog4designer.github.io/', target: '_blank'
     %br
     =link_to 'CC BY-NC-SA 2.1', 'http://creativecommons.org/licenses/by-nc-sa/2.1/jp/', target: '_blank'
-
-  .footer-repository
+    &nbsp;
+    = "/"
+    &nbsp;
     =link_to 'https://github.com/taea/ktra', target: '_blank', title: 'Fork me!' do
-      %i.fa.fa-github
+      Fork me on
+      &nbsp;
+      %strong<> GitHub


### PR DESCRIPTION
かわいいんだけど、よく考えたら GitHub 製プロダクトみたいだなと思ったので直した

![image](https://cloud.githubusercontent.com/assets/341101/2687073/ca5a1d66-c232-11e3-89b7-1b4832cf2cc9.png)

↓

![image](https://cloud.githubusercontent.com/assets/341101/2687075/ef7d217e-c232-11e3-9423-67a4746edb9a.png)
