### PR TITLE
ツイートリンクの時に出るステータスを可変にした

### DIFF
--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -8,7 +8,8 @@
       = render ("tasks/statuses/#{@task.status}"), task: @task
     = render 'form'
     .tweet
-      = link_to "http://twitter.com/share?text=TODO: #{@task.title} [#{@task.point}pt] @ktra_app&url=https://ktra.herokuapp.com", target: '_blank' do
+      - status_text = @task.status == 'unstarted' ? 'TODO' : @task.status.upcase
+      = link_to "http://twitter.com/share?text=#{status_text}: #{@task.title} [#{@task.point}pt] @ktra_app&url=https://ktra.herokuapp.com", target: '_blank' do
         %i.fa.fa-twitter
         Tweet this task
     .time


### PR DESCRIPTION
どんなステータスの場合でも `TODO:なんとか〜` とツイートされてた。
- `@task.status == 'unstarted'` の場合は `TODO: なんとか〜` とツイート
- `@task.status == 'doing'` の場合は `DOING: なんとか〜` とツイート
- `@task.status == 'done'` の場合は `DONE: なんとか〜` とツイート

なおした

なぜ最初からこうしなかったのか( ˘ω˘)
